### PR TITLE
HTML editor cursor fix

### DIFF
--- a/challenge.html
+++ b/challenge.html
@@ -530,7 +530,10 @@ x-init="
 
               ```-->
               <div class="panel-block growWithSiblings" 
-                x-data="{editor:null}" 
+                x-data="{
+                  editor:null,
+                  editorHasFocus: false
+                }" 
                 x-init="
                   // Setup Ace editor
                   editor = ace.edit('htmlAceEditor');
@@ -546,13 +549,28 @@ x-init="
                   });
                   // Add HTML content from the challenge
                   editor.setValue(content, -1);
+                  
+                  // Track editor focus state
+                  editor.on('focus', function() {
+                    editorHasFocus = true;
+                  });
+                  
+                  editor.on('blur', function() {
+                    editorHasFocus = false;
+                    // Ensure content is synchronized when focus is lost
+                    if (editor.getValue() !== content) {
+                      editor.setValue(content, -1);
+                    }
+                  });
+                  
                   // If editor changes, update model
                   editor.session.on('change', () => {
                     content = editor.getValue();
                   });
-                  // If model changes, update editor
+                  
+                  // If model changes, update editor only if editor doesn't have focus
                   $watch('content', (newValue) => {
-                    if (newValue !== editor.getValue()) {
+                    if (!editorHasFocus && newValue !== editor.getValue()) {
                       editor.setValue(newValue, -1);
                     }
                   });

--- a/challenges/cameracomeback/cameracomeback.json
+++ b/challenges/cameracomeback/cameracomeback.json
@@ -6,7 +6,8 @@
     "level":1,
     "number":1,
     "answers":[
-        "a750b1d49776b2db6797fb2b973c6d6638461f08c31e551a35b01564731000c2"
+        "a750b1d49776b2db6797fb2b973c6d6638461f08c31e551a35b01564731000c2",
+        "16f941f5ce855f8b57602f0e4a36a1b91e8a70db6f10778b19946f8171b619e8"
     ],
     "answerCaseSensitive":false,
     "answerAlphaNumeric":true,


### PR DESCRIPTION
This change ensures that the HTML editor live-updates the challenge page, but does this does not reciprocally update the content in the editor until the user changes focus. This prevents the cursor from moving to the start with every character change, and prevents the browser from live-fixing syntax issues during edits.